### PR TITLE
Fix issue with TQDM when flushing upon error

### DIFF
--- a/ekg_creator/utilities/context_manager_tqdm.py
+++ b/ekg_creator/utilities/context_manager_tqdm.py
@@ -16,6 +16,10 @@ class DummyFile(object):
         # Avoid print() second call (useless \n)
         if len(x.rstrip()) > 0:
             tqdm.write(x, file=self.file)
+            
+    def flush(self) -> None:
+        # NO-OP so Python doesn't complain about missing flush method.
+        pass
 
 
 # Make class to use __enter__ and __exit__ to avoid using _with_ to open and close context


### PR DESCRIPTION
This fixes an issue where additional errors where thrown when an error occurred during printing to stdout.